### PR TITLE
Sitemap: generate via jekyll-sitemap; dynamic robots.txt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,5 @@ group :development do
   gem "webrick", "~> 1.8"
 end
 
+# Generate sitemap.xml automatically based on site.url/baseurl
+gem "jekyll-sitemap", "~> 1.4"

--- a/_config.yml
+++ b/_config.yml
@@ -11,3 +11,6 @@ exclude:
   - vendor
   - .github
   - .devcontainer
+
+plugins:
+  - jekyll-sitemap

--- a/robots.txt
+++ b/robots.txt
@@ -1,5 +1,6 @@
+---
+---
 User-agent: *
 Allow: /
 
-Sitemap: https://electivus.com/sitemap.xml
-
+Sitemap: {{ site.url | default: "https://electivus.com" }}{{ site.baseurl }}/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://electivus.com/</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-</urlset>
-


### PR DESCRIPTION
Motivation: Auto-generate sitemap from site configuration and ensure robots.txt always references the correct sitemap URL. Changes: Add jekyll-sitemap plugin, enable it in _config.yml, remove static sitemap.xml, and make robots.txt dynamic with site.url/baseurl. Notes: No Pages settings change needed; ensure _config.yml has correct url and baseurl. Local test: run bundle install and bundle exec jekyll build; sitemap.xml will be generated under _site.