### PR TITLE
CI: disable Bundler frozen mode in Actions

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -25,10 +25,13 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'
-          bundler-cache: true
+          bundler-cache: false
+
+      - name: Allow lockfile updates (disable frozen)
+        run: bundle config set frozen false
 
       - name: Install dependencies
-        run: bundle install --without development test
+        run: bundle install --jobs 4 --without development test
 
       - name: Build site with Jekyll (latest)
         env:
@@ -50,4 +53,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-


### PR DESCRIPTION
This PR fixes the Pages build error caused by Bundler running in frozen/deployment mode before the lockfile can be updated.

Changes
- Disable `bundler-cache` in `ruby/setup-ruby` to avoid auto-install in frozen mode.
- Add step to run `bundle config set frozen false` so lockfile updates are allowed when `Gemfile` changes (e.g., `jekyll-sitemap`).
- Keep explicit `bundle install --jobs 4 --without development test` for clarity and speed.

After merging, consider re-enabling `bundler-cache: true` once the updated `Gemfile.lock` is committed and stable for faster builds.