### PR TITLE
site: update Apex Log Viewer links to new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This directory contains a static site ready to be published to the organizationâ
 ## Customize
 
 - Edit `index.html` to update content, links, and visuals.
-- The Apex Log Viewer link points to `Electivus/apex-log-viewer`.
+- The Apex Log Viewer link points to `Electivus/Apex-Log-Viewer`.
 - Add pages/assets as needed (e.g., `assets/img/`, `docs/`, etc.).
 
 ## Structure

--- a/apex-log-viewer/index.html
+++ b/apex-log-viewer/index.html
@@ -27,7 +27,7 @@ layout: none
         "author": { "@type": "Organization", "name": "Electivus", "url": "{{ site.url | default: 'https://electivus.com' }}{{ site.baseurl }}/" },
         "description": "A paginated, searchable Apex logs panel for VS Code with filters, sorting, and Apex Replay Debugger integration.",
         "url": "{{ site.url | default: 'https://electivus.com' }}{{ site.baseurl }}{{ page.url }}",
-        "downloadUrl": "https://github.com/Electivus/apex-log-viewer/releases",
+        "downloadUrl": "https://github.com/Electivus/Apex-Log-Viewer/releases",
         "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
       }
     </script>
@@ -69,8 +69,8 @@ layout: none
           </div>
           <p class="muted">A paginated, searchable Apex logs panel for VS Code with filters, sorting, and Apex Replay Debugger integration.</p>
           <div class="cta" style="margin-top:10px">
-            <a class="button primary" target="_blank" rel="noopener" href="https://github.com/Electivus/apex-log-viewer">View on GitHub</a>
-            <a class="button" target="_blank" rel="noopener" href="https://github.com/Electivus/apex-log-viewer/releases">Download VSIX</a>
+            <a class="button primary" target="_blank" rel="noopener" href="https://github.com/Electivus/Apex-Log-Viewer">View on GitHub</a>
+            <a class="button" target="_blank" rel="noopener" href="https://github.com/Electivus/Apex-Log-Viewer/releases">Download VSIX</a>
           </div>
           <div class="badges">
             <span class="badge">VS Code 1.87+</span>
@@ -123,8 +123,8 @@ sf org list        # verify orgs</code></pre>
                 <li>In VS Code, run: <em>Extensions: Install from VSIX…</em></li>
               </ol>
               <p><strong>Option B — Development</strong></p>
-              <pre><code>git clone https://github.com/Electivus/apex-log-viewer.git
-cd apex-log-viewer
+              <pre><code>git clone https://github.com/Electivus/Apex-Log-Viewer.git
+cd Apex-Log-Viewer
 npm install
 npm run build
 # Press F5 to launch the Extension Development Host
@@ -156,8 +156,8 @@ npm run build
             <li><strong>No orgs detected</strong>: Authenticate with <code>sf org login web</code> and verify with <code>sf org list</code>.</li>
           </ul>
           <div class="cta" style="margin-top:12px">
-            <a class="button" target="_blank" rel="noopener" href="https://github.com/Electivus/apex-log-viewer/blob/main/CHANGELOG.md">Changelog</a>
-            <a class="button" target="_blank" rel="noopener" href="https://github.com/Electivus/apex-log-viewer/issues">Report an issue</a>
+            <a class="button" target="_blank" rel="noopener" href="https://github.com/Electivus/Apex-Log-Viewer/blob/main/CHANGELOG.md">Changelog</a>
+            <a class="button" target="_blank" rel="noopener" href="https://github.com/Electivus/Apex-Log-Viewer/issues">Report an issue</a>
           </div>
         </div>
       </section>
@@ -174,4 +174,3 @@ npm run build
     </script>
   </body>
   </html>
-

--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
           <p>Paginated, searchable Apex logs panel for VS Code with filters, sorting, and Apex Replay Debugger integration.</p>
           <div class="cta">
             <a class="button primary" href="{{ '/apex-log-viewer/' | relative_url }}">Learn more</a>
-            <a class="button" target="_blank" rel="noopener" href="https://github.com/Electivus/apex-log-viewer">View on GitHub</a>
+            <a class="button" target="_blank" rel="noopener" href="https://github.com/Electivus/Apex-Log-Viewer">View on GitHub</a>
           </div>
         </div>
       </section>


### PR DESCRIPTION
Update site links and examples to use Electivus/Apex-Log-Viewer.\n\n- Home CTA link\n- Product page GitHub/Downloads/Changelog/Issues\n- Clone instructions and cd path\n- README reference\n\nRationale: extension repository moved; fix public links.